### PR TITLE
Change getting item progress visibility

### DIFF
--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFolderFragment.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFolderFragment.java
@@ -3,7 +3,11 @@ package com.box.androidsdk.browse.fragments;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
+import com.box.androidsdk.browse.R;
 import com.box.androidsdk.browse.service.BoxResponseIntent;
 import com.box.androidsdk.content.models.BoxFolder;
 import com.box.androidsdk.content.models.BoxIterator;
@@ -49,21 +53,35 @@ public class BoxBrowseFolderFragment extends BoxBrowseFragment {
     @Override
     protected void handleResponse(BoxResponseIntent intent) {
         super.handleResponse(intent);
-        if (!intent.isSuccess()) {
-            checkConnectivity();
-            return;
-        }
         if (intent.getAction().equals(BoxRequestsFolder.GetFolderWithAllItems.class.getName())) {
-            onFolderFetched((BoxFolder) intent.getResult());
-            if (mSwipeRefresh != null) {
-                mSwipeRefresh.setRefreshing(false);
+            final BoxRequestsFolder.GetFolderWithAllItems request =
+                    (BoxRequestsFolder.GetFolderWithAllItems) intent.getRequest();
+            if (mFolder != null && mFolder.getId().equals(request.getId())) {
+                if (mSwipeRefresh != null && !intent.isFromCache()) {
+                    mSwipeRefresh.setRefreshing(false);
+                }
+                if (intent.isSuccess()) {
+                    final BoxFolder holder = (BoxFolder) intent.getResult();
+                    if (holder != null) {
+                        mProgress.setVisibility(View.GONE);
+                        onFolderFetched(holder);
+                    }
+                } else {
+                    mProgress.setVisibility(View.GONE);
+                    checkConnectivity();
+                    Toast.makeText(getContext(),
+                            R.string.box_browsesdk_problem_fetching_folder,
+                            Toast.LENGTH_LONG).show();
+                }
             }
         }
     }
 
     @Override
     protected void loadItems() {
-        mProgress.setVisibility(View.VISIBLE);
+        if (mItems == null) {
+            mProgress.setVisibility(View.VISIBLE);
+        }
         getController().execute(getController().getFolderWithAllItems(mFolder.getId()));
     }
 
@@ -87,15 +105,13 @@ public class BoxBrowseFolderFragment extends BoxBrowseFragment {
      *
      * @param folder that has been fetched
      */
-    protected void onFolderFetched(BoxFolder folder) {
-        if (folder != null && mFolder.getId().equals(folder.getId())) {
-            BoxIteratorItems items = folder.getItemCollection();
-            if (items != null && items.getEntries() != null && items.fullSize() != null && (items.size() > 0 || items.fullSize() == 0)) {
-                updateItems(folder.getItemCollection().getEntries());
-            }
-            mFolder = createFolderWithoutItems(folder);
-            notifyUpdateListeners();
+    protected void onFolderFetched(@NonNull BoxFolder folder) {
+        BoxIteratorItems items = folder.getItemCollection();
+        if (items != null && items.getEntries() != null && items.fullSize() != null && (items.size() > 0 || items.fullSize() == 0)) {
+            updateItems(folder.getItemCollection().getEntries());
         }
+        mFolder = createFolderWithoutItems(folder);
+        notifyUpdateListeners();
     }
 
 

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BoxResponseIntent.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BoxResponseIntent.java
@@ -16,21 +16,30 @@ import com.box.androidsdk.content.requests.BoxResponse;
  */
 public class BoxResponseIntent<E extends BoxObject> extends Intent {
     private final BoxResponse<E> mResponse;
+    private final boolean mFromCache;
 
     /**
      * Instantiates a new Box response intent.
      *
      * @param response the response
      */
-    public BoxResponseIntent(BoxResponse<E> response) {
+    public BoxResponseIntent(BoxResponse<E> response, boolean fromCache) {
         mResponse = response;
+        mFromCache = fromCache;
         if (mResponse.getRequest() != null) {
             setAction(mResponse.getRequest().getClass().getName());
         }
     }
 
     /**
-     * Is success boolean. returns truw if the request was successful
+     * Return true if the response was gotten from cache.
+     */
+    public boolean isFromCache() {
+        return mFromCache;
+    }
+
+    /**
+     * Is success boolean. returns true if the request was successful
      *
      * @return the boolean
      */
@@ -83,6 +92,7 @@ public class BoxResponseIntent<E extends BoxObject> extends Intent {
     public void writeToParcel(Parcel out, int flags) {
         super.writeToParcel(out, flags);
         out.writeSerializable(mResponse);
+        out.writeInt(mFromCache ? 1 : 0);
     }
 
     public static final Parcelable.Creator<BoxResponseIntent> CREATOR = new Creator<BoxResponseIntent>() {
@@ -100,6 +110,7 @@ public class BoxResponseIntent<E extends BoxObject> extends Intent {
     private BoxResponseIntent(Parcel in) {
         readFromParcel(in);
         mResponse = (BoxResponse) in.readSerializable();
+        mFromCache = in.readInt() != 0;
     }
 }
 

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BrowseController.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/BrowseController.java
@@ -2,6 +2,7 @@ package com.box.androidsdk.browse.service;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+
 import androidx.collection.LruCache;
 
 import com.box.androidsdk.browse.uidata.ThumbnailManager;
@@ -14,7 +15,6 @@ import com.box.androidsdk.content.requests.BoxRequestUpdateSharedItem;
 import com.box.androidsdk.content.requests.BoxRequestsFile;
 import com.box.androidsdk.content.requests.BoxRequestsFolder;
 import com.box.androidsdk.content.requests.BoxRequestsSearch;
-import com.box.androidsdk.content.requests.BoxResponse;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -71,20 +71,18 @@ public interface BrowseController {
     void execute(BoxRequest request);
 
     /***
-     * Sets the default compeltion listener that will be used after the completion of a BoxRequest
+     * Sets the default completed listener that will be used after the completion of a BoxRequest
      *
      * @param listener the listener
      * @return this
      */
     BrowseController setCompletedListener(BoxFutureTask.OnCompletedListener listener);
 
-    /**
-     * Error handler for whenever an error occurs from a request
-     *
-     * @param context  the context
-     * @param response response returned from the server that contains the request, result, and exception
+    /***
+     * Sets the completed listener for cache that will be used after received the cached result of a BoxRequest
+     * @return this
      */
-    void onError(Context context, BoxResponse response);
+    BrowseController setCacheCompletedListener(BoxFutureTask.OnCompletedListener listener);
 
     /**
      * Gets recent searches.

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/CompletionListener.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/service/CompletionListener.java
@@ -1,29 +1,31 @@
 package com.box.androidsdk.browse.service;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.box.androidsdk.content.BoxFutureTask;
 import com.box.androidsdk.content.requests.BoxResponse;
 import com.box.androidsdk.content.utils.BoxLogUtils;
-
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 public class CompletionListener implements BoxFutureTask.OnCompletedListener {
 
     private static final String TAG = CompletionListener.class.getName();
 
     private final LocalBroadcastManager mBroadcastManager;
+    private final boolean mFromCache;
 
     /**
      * Instantiates a new Completion listener.
      *
      * @param broadcastManager the broadcast manager
      */
-    public CompletionListener(LocalBroadcastManager broadcastManager) {
+    public CompletionListener(LocalBroadcastManager broadcastManager, boolean fromCache) {
         mBroadcastManager = broadcastManager;
+        mFromCache = fromCache;
     }
 
     @Override
     public void onCompleted(BoxResponse response) {
-        BoxResponseIntent intent = new BoxResponseIntent(response);
+        final BoxResponseIntent intent = new BoxResponseIntent(response, mFromCache);
         if (!response.isSuccess()) {
             BoxLogUtils.e(TAG, response.getException());
         }


### PR DESCRIPTION
- Hide ProgressBar if item has been loaded
- Hide ProgressBar on error
- Don't invoke `SwipeRefreshLayout#setRefreshing(false)` on response received from cache
- Fix forgetting show Toast on error