### PR TITLE
targetSdkを36に更新

### DIFF
--- a/box-browse-sample/build.gradle
+++ b/box-browse-sample/build.gradle
@@ -38,5 +38,6 @@ android {
 
 dependencies {
     implementation project(':box-browse-sdk')
+    implementation "androidx.core:core:1.17.0"
     implementation "androidx.appcompat:appcompat:1.7.1"
 }

--- a/box-browse-sample/src/main/java/com/box/androidsdk/sample/SampleBrowseActivity.java
+++ b/box-browse-sample/src/main/java/com/box/androidsdk/sample/SampleBrowseActivity.java
@@ -1,11 +1,20 @@
 package com.box.androidsdk.sample;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Button;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.box.androidsdk.browse.activities.BoxBrowseFileActivity;
 import com.box.androidsdk.browse.activities.BoxBrowseFolderActivity;
@@ -15,8 +24,6 @@ import com.box.androidsdk.content.BoxConfig;
 import com.box.androidsdk.content.models.BoxFolder;
 import com.box.androidsdk.content.models.BoxItem;
 import com.box.androidsdk.content.models.BoxSession;
-
-import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.Serializable;
 
@@ -28,15 +35,25 @@ public class SampleBrowseActivity extends AppCompatActivity {
 
     public static final String ROOT_FOLDER_ID = "0";
 
-    private Button btnFilePicker;
-    private Button btnFolderPicker;
-
     private BoxSession session;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.enableEdgeToEdge(getWindow());
         setContentView(R.layout.activity_sample_browse);
+        final Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        final View root = findViewById(R.id.root);
+        ViewCompat.setOnApplyWindowInsetsListener(root,
+                (v, windowInsets) -> {
+                    final Insets insets = windowInsets.getInsets(displayCutout() | systemBars());
+                    root.setPadding(insets.left, 0, insets.right, 0);
+                    toolbar.setPadding(0, insets.top, 0, 0);
+                    return WindowInsetsCompat.CONSUMED;
+                });
+
         BoxConfig.IS_LOG_ENABLED = true;
         BoxConfig.CLIENT_ID = getString(R.string.box_clientId);
         BoxConfig.CLIENT_SECRET = getString(R.string.box_clientSecret);
@@ -78,8 +95,6 @@ public class SampleBrowseActivity extends AppCompatActivity {
                                         boxItem.getId(), boxItem.getName(), boxItem.getSharedLink().getURL()),
                                 Toast.LENGTH_LONG).show();
                     }
-                } else {
-                    // No file selected
                 }
                 break;
             case REQUEST_CODE_FOLDER_PICKER:
@@ -88,28 +103,15 @@ public class SampleBrowseActivity extends AppCompatActivity {
                     if (boxFolder != null) {
                         Toast.makeText(this, String.format("Folder picked, id: %s; name: %s", boxFolder.getId(), boxFolder.getName()), Toast.LENGTH_LONG).show();
                     }
-                } else {
-                    // No folder selected
                 }
                 break;
             default:
+                super.onActivityResult(requestCode, resultCode, data);
         }
     }
 
     private void initUI() {
-        btnFilePicker = (Button) findViewById(R.id.btnFilePicker);
-        btnFolderPicker = (Button) findViewById(R.id.btnFolderPicker);
-        btnFilePicker.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                launchFilePicker();
-            }
-        });
-        btnFolderPicker.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                launchFolderPicker();
-            }
-        });
+        findViewById(R.id.btnFilePicker).setOnClickListener(view -> launchFilePicker());
+        findViewById(R.id.btnFolderPicker).setOnClickListener(view -> launchFolderPicker());
     }
 }

--- a/box-browse-sample/src/main/res/layout/activity_sample_browse.xml
+++ b/box-browse-sample/src/main/res/layout/activity_sample_browse.xml
@@ -1,21 +1,31 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/box_browsesdk_horizontal_margin"
-    android:paddingRight="@dimen/box_browsesdk_horizontal_margin"
-    android:paddingTop="@dimen/box_browsesdk_vertical_margin"
-    android:paddingBottom="@dimen/box_browsesdk_vertical_margin"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".SampleBrowseActivity">
+    tools:context="com.box.androidsdk.sample.SampleBrowseActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
 
     <Button
         android:text="File Picker"
         android:layout_height="60dp"
         android:layout_width="wrap_content"
+        android:layout_marginVertical="@dimen/box_browsesdk_vertical_margin"
+        android:layout_marginHorizontal="@dimen/box_browsesdk_horizontal_margin"
         android:id="@+id/btnFilePicker" />
     <Button
         android:text="Folder Picker"
         android:layout_height="60dp"
         android:layout_width="wrap_content"
-        android:id="@+id/btnFolderPicker" />
+        android:layout_marginVertical="@dimen/box_browsesdk_vertical_margin"
+        android:layout_marginHorizontal="@dimen/box_browsesdk_horizontal_margin"
+        android:id="@+id/btnFolderPicker"
+        />
 
 </LinearLayout>

--- a/box-browse-sample/src/main/res/values/styles.xml
+++ b/box-browse-sample/src/main/res/values/styles.xml
@@ -1,9 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 
 </resources>

--- a/box-browse-sdk/build.gradle
+++ b/box-browse-sdk/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     api 'com.box:box-android-sdk:5.0.0'
 
+    implementation "androidx.core:core:1.17.0"
     implementation "androidx.appcompat:appcompat:1.7.1"
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.2.0"

--- a/box-browse-sdk/src/main/AndroidManifest.xml
+++ b/box-browse-sdk/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
             android:theme="@style/BrowseTheme" >
         </activity>
         <activity android:name=".activities.FilterSearchResults"
-            android:label="Filter Search Results"
+            android:label="@string/filter_search_results"
             android:theme="@style/BrowseTheme" >
         </activity>
     </application>

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseActivity.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseActivity.java
@@ -102,7 +102,9 @@ public abstract class BoxBrowseActivity extends BoxThreadPoolExecutorActivity im
         mRecentSearchesListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                String query = mRecentSearchesAdapter.getItem(position - mRecentSearchesListView.getHeaderViewsCount());
+                position = position - mRecentSearchesListView.getHeaderViewsCount();
+                if (position < 0) return;
+                String query = mRecentSearchesAdapter.getItem(position);
                 mSearchView.setQuery(query, false);
             }
         });
@@ -151,7 +153,7 @@ public abstract class BoxBrowseActivity extends BoxThreadPoolExecutorActivity im
             // Launch search experience
             return true;
         } else if (id == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else {
             return super.onOptionsItemSelected(item);

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseActivity.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseActivity.java
@@ -96,14 +96,14 @@ public abstract class BoxBrowseActivity extends BoxThreadPoolExecutorActivity im
     public void initRecentSearches() {
         mRecentSearchesHeader = getLayoutInflater().inflate(com.box.androidsdk.browse.R.layout.box_browsesdk_recent_searches_header, null);
         mRecentSearchesFooter = getLayoutInflater().inflate(com.box.androidsdk.browse.R.layout.box_browsesdk_recent_searches_footer, null);
-        mRecentSearchesListView = (ListView) findViewById(R.id.recentSearchesListView);
+        mRecentSearchesListView = findViewById(R.id.recentSearchesListView);
         mRecentSearchesListView.addHeaderView(mRecentSearchesHeader);
         mRecentSearchesListView.addFooterView(mRecentSearchesFooter);
         mRecentSearchesListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 position = position - mRecentSearchesListView.getHeaderViewsCount();
-                if (position < 0) return;
+                if (position < 0 || position >= mRecentSearchesAdapter.getCount()) return;
                 String query = mRecentSearchesAdapter.getItem(position);
                 mSearchView.setQuery(query, false);
             }
@@ -262,7 +262,7 @@ public abstract class BoxBrowseActivity extends BoxThreadPoolExecutorActivity im
 
     private void setRecentViewVisible(final boolean visible) {
         mRecentSearchesListView.setVisibility(visible? View.VISIBLE : View.GONE);
-        if (mRecentSearches == null || mRecentSearches.size() == 0) {
+        if (mRecentSearches == null || mRecentSearches.isEmpty()) {
             mRecentSearchesHeader.setVisibility(View.GONE);
             mRecentSearchesFooter.setVisibility(View.GONE);
         } else {

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseFileActivity.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseFileActivity.java
@@ -1,11 +1,22 @@
 package com.box.androidsdk.browse.activities;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.ime;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
+import android.view.View;
 import android.widget.Toast;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.ViewGroupCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.box.androidsdk.browse.R;
 import com.box.androidsdk.browse.models.BoxSessionDto;
@@ -37,12 +48,30 @@ public class BoxBrowseFileActivity extends BoxBrowseActivity {
      */
     public static final String EXTRA_BOX_EXTENSION_FILTER = "extraBoxExtensionFilter";
 
-
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.enableEdgeToEdge(getWindow());
         setContentView(R.layout.box_browsesdk_activity_file);
+        final View root = findViewById(R.id.root);
+        final View toolbar = findViewById(R.id.box_action_bar);
+        final View recentSearches = findViewById(R.id.recentSearchesListView);
+        final View fragmentContainer = findViewById(R.id.box_browsesdk_fragment_container);
+        ViewGroupCompat.installCompatInsetsDispatch(root);
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(displayCutout() | systemBars() | ime());
+            root.setPadding(insets.left, 0, insets.right, 0);
+            toolbar.setPadding(0, insets.top, 0, 0);
+            recentSearches.setPadding(0, 0, 0, insets.bottom);
+
+            ViewCompat.dispatchApplyWindowInsets(
+                    fragmentContainer,
+                    windowInsets.inset(insets.left, insets.top, insets.right, 0)
+            );
+
+            return WindowInsetsCompat.CONSUMED;
+        });
+
         initToolbar();
         initRecentSearches();
         if (getSupportFragmentManager().getBackStackEntryCount() < 1){

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseFolderActivity.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/BoxBrowseFolderActivity.java
@@ -1,5 +1,9 @@
 package com.box.androidsdk.browse.activities;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.ime;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -10,6 +14,10 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.box.androidsdk.browse.R;
 import com.box.androidsdk.browse.fragments.BoxBrowseFragment;
@@ -111,9 +119,24 @@ public class BoxBrowseFolderActivity extends BoxBrowseActivity implements View.O
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.enableEdgeToEdge(getWindow());
         setContentView(R.layout.box_browsesdk_activity_folder);
 
-        mSelectFolderButton = (Button) findViewById(R.id.box_browsesdk_select_folder_button);
+        final View root = findViewById(R.id.root);
+        final View toolbar = findViewById(R.id.box_action_bar);
+        final View footer = findViewById(R.id.footer);
+        final View recentSearches = findViewById(R.id.recentSearchesListView);
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(displayCutout() | systemBars() | ime());
+            root.setPadding(insets.left, 0, insets.right, 0);
+            toolbar.setPadding(0, insets.top, 0, 0);
+            recentSearches.setPadding(0, 0, 0, insets.bottom);
+            footer.setPadding(0, 0, 0, insets.bottom);
+
+            return WindowInsetsCompat.CONSUMED;
+        });
+
+        mSelectFolderButton = findViewById(R.id.box_browsesdk_select_folder_button);
         mSelectFolderButton.setOnClickListener(this);
         initToolbar();
         initRecentSearches();
@@ -168,8 +191,6 @@ public class BoxBrowseFolderActivity extends BoxBrowseActivity implements View.O
                 if (response.getException() instanceof BoxException) {
                     if (((BoxException) response.getException()).getResponseCode() == HttpURLConnection.HTTP_CONFLICT) {
                         resId = R.string.box_browsesdk_create_folder_conflict;
-                    } else {
-
                     }
                 }
                 Toast.makeText(this, resId, Toast.LENGTH_LONG).show();

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/FilterSearchResults.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/activities/FilterSearchResults.java
@@ -1,15 +1,26 @@
 package com.box.androidsdk.browse.activities;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.ViewGroupCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.FragmentTransaction;
 
 import com.box.androidsdk.browse.R;
 import com.box.androidsdk.browse.fragments.BoxFilterSearchResultsFragment;
 import com.box.androidsdk.browse.models.BoxSearchFilters;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentTransaction;
 
 /**
  * The type Filter search results.
@@ -23,7 +34,23 @@ public class FilterSearchResults extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.enableEdgeToEdge(getWindow());
         setContentView(R.layout.activity_filter_search_results2);
+        setSupportActionBar(findViewById(R.id.box_action_bar));
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        final View root = findViewById(R.id.root);
+        final View toolbar = findViewById(R.id.box_action_bar);
+        final View fragmentContainer = findViewById(R.id.fragmentContainer);
+        ViewGroupCompat.installCompatInsetsDispatch(root);
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(displayCutout() | systemBars());
+            root.setPadding(insets.left, 0, insets.right, 0);
+            toolbar.setPadding(0, insets.top, 0, 0);
+            ViewCompat.dispatchApplyWindowInsets(fragmentContainer, windowInsets.inset(insets.left, insets.top, insets.right, 0));
+            return WindowInsetsCompat.CONSUMED;
+        });
+
         if (savedInstanceState != null) {
             mFilters = (BoxSearchFilters) savedInstanceState.getSerializable(EXTRA_FILTERS);
         }
@@ -41,6 +68,14 @@ public class FilterSearchResults extends AppCompatActivity {
         }
     }
 
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
 
     @Override
     protected void onSaveInstanceState(Bundle savedInstanceState) {

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFragment.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxBrowseFragment.java
@@ -1,12 +1,15 @@
 package com.box.androidsdk.browse.fragments;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.ime;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.graphics.Canvas;
-import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -18,6 +21,11 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -244,9 +252,18 @@ public abstract class BoxBrowseFragment extends Fragment implements SwipeRefresh
         return mRootView;
     }
 
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(displayCutout() | systemBars() | ime());
+            mItemsView.setPadding(0, 0, 0, insets.bottom);
+            return WindowInsetsCompat.CONSUMED;
+        });
+    }
+
     protected void initRecyclerView(RecyclerView view){
         view.addItemDecoration(new BoxItemDividerDecoration(getResources()));
-        view.addItemDecoration(new FooterDecoration(getResources()));
         view.setLayoutManager(new LinearLayoutManager(getActivity()));
         if (view.getItemAnimator() instanceof SimpleItemAnimator) {
             ((SimpleItemAnimator) view.getItemAnimator()).setSupportsChangeAnimations(false);
@@ -697,27 +714,6 @@ public abstract class BoxBrowseFragment extends Fragment implements SwipeRefresh
 
                 mDivider.setBounds(left, top, right, bottom);
                 mDivider.draw(c);
-            }
-        }
-    }
-
-    private static class FooterDecoration extends RecyclerView.ItemDecoration {
-        private final int mFooterPadding;
-
-        /**
-         * Instantiates a new Footer decoration.
-         *
-         * @param resources the resources
-         */
-        public FooterDecoration(Resources resources) {
-            mFooterPadding = (int) resources.getDimension(R.dimen.box_browsesdk_list_footer_padding);
-        }
-
-        @Override
-        public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
-            super.getItemOffsets(outRect, view, parent, state);
-            if (parent.getChildAdapterPosition(view) == parent.getAdapter().getItemCount() -1) {
-                outRect.bottom = mFooterPadding;
             }
         }
     }

--- a/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxFilterSearchResultsFragment.java
+++ b/box-browse-sdk/src/main/java/com/box/androidsdk/browse/fragments/BoxFilterSearchResultsFragment.java
@@ -1,5 +1,8 @@
 package com.box.androidsdk.browse.fragments;
 
+import static androidx.core.view.WindowInsetsCompat.Type.displayCutout;
+import static androidx.core.view.WindowInsetsCompat.Type.systemBars;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -19,7 +22,12 @@ import com.box.androidsdk.browse.models.BoxSearchFilters;
 
 import java.util.HashMap;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 
 /**
@@ -80,6 +88,17 @@ public class BoxFilterSearchResultsFragment extends Fragment {
         setup(view);
 
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        final View clearApplyBar = view.findViewById(R.id.clear_apply_bar);
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(displayCutout() | systemBars());
+            clearApplyBar.setPadding(0, 0, 0, insets.bottom);
+            return WindowInsetsCompat.CONSUMED;
+        });
     }
 
     /**

--- a/box-browse-sdk/src/main/res/drawable-mdpi/box_toolbar_dropshadow.xml
+++ b/box-browse-sdk/src/main/res/drawable-mdpi/box_toolbar_dropshadow.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <gradient
-        android:startColor="@android:color/transparent"
-        android:endColor="@color/box_browsesdk_shadow"
-        android:angle="90" />
-</shape>
-

--- a/box-browse-sdk/src/main/res/layout/activity_filter_search_results2.xml
+++ b/box-browse-sdk/src/main/res/layout/activity_filter_search_results2.xml
@@ -1,14 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    android:orientation="vertical"
     tools:context="com.box.androidsdk.browse.activities.FilterSearchResults"
-    android:background="#FFFFFF">
+    >
 
-    <FrameLayout
+    <androidx.appcompat.widget.Toolbar
+        style="@style/BoxToolbar"
+        android:id="@+id/box_action_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-    </FrameLayout>
-</RelativeLayout>
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        />
+
+</LinearLayout>

--- a/box-browse-sdk/src/main/res/layout/box_browsesdk_activity_file.xml
+++ b/box-browse-sdk/src/main/res/layout/box_browsesdk_activity_file.xml
@@ -1,31 +1,32 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/box_background">
-    <include layout="@layout/box_browsesdk_toolbar"
-        android:id="@+id/mainToolbar"/>
-    <FrameLayout
+
+    <androidx.appcompat.widget.Toolbar
+        style="@style/BoxToolbar"
+        android:id="@+id/box_action_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <androidx.fragment.app.FragmentContainerView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/mainToolbar">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="6dp"
-            android:background="@drawable/box_toolbar_dropshadow" />
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:id="@+id/box_browsesdk_fragment_container">
-        </FrameLayout>
-    </FrameLayout>
+        android:layout_below="@id/box_action_bar"
+        android:id="@+id/box_browsesdk_fragment_container"
+        />
     <ListView
         android:id="@+id/recentSearchesListView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/mainToolbar"
+        android:layout_below="@id/box_action_bar"
         android:background="#55000000"
         android:visibility="gone"
         android:dividerHeight="0dp"
-        android:divider="@null"/>
+        android:divider="@null"
+        android:clipToPadding="false"
+        />
 </RelativeLayout>

--- a/box-browse-sdk/src/main/res/layout/box_browsesdk_activity_folder.xml
+++ b/box-browse-sdk/src/main/res/layout/box_browsesdk_activity_folder.xml
@@ -1,48 +1,53 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/box_background">
-    <include layout="@layout/box_browsesdk_toolbar"
-        android:id="@+id/mainToolbar"/>
-    <FrameLayout
+    android:background="@color/box_background"
+    >
+
+    <androidx.appcompat.widget.Toolbar
+        style="@style/BoxToolbar"
+        android:id="@+id/box_action_bar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/mainToolbar">
+        android:layout_height="wrap_content"
+        />
+
+    <FrameLayout
+        android:id="@+id/footer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true">
         <View
             android:layout_width="match_parent"
-            android:layout_height="6dp"
-            android:background="@drawable/box_toolbar_dropshadow" />
-        <FrameLayout
-            android:id="@+id/box_browsesdk_fragment_container"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider" />
+        <Button
+            android:id="@+id/box_browsesdk_select_folder_button"
+            style="@style/BoxDialogButton"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="@dimen/box_browsesdk_persistent_footer_height">
-        </FrameLayout>
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/box_browsesdk_persistent_footer_height"
-            android:layout_gravity="bottom">
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="?android:attr/listDivider" />
-            <Button
-                android:id="@+id/box_browsesdk_select_folder_button"
-                style="@style/BoxDialogButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:enabled="false"
-                android:text="@string/box_browsesdk_select_folder" />
-        </FrameLayout>
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="@string/box_browsesdk_select_folder" />
     </FrameLayout>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/box_browsesdk_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/box_action_bar"
+        android:layout_above="@id/footer"
+        />
+
     <ListView
         android:id="@+id/recentSearchesListView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/mainToolbar"
+        android:layout_below="@id/box_action_bar"
         android:background="#55000000"
         android:visibility="gone"
         android:dividerHeight="0dp"
-        android:divider="@null"/>
+        android:divider="@null"
+        android:clipToPadding="false"
+        />
 </RelativeLayout>

--- a/box-browse-sdk/src/main/res/layout/box_browsesdk_fragment_browse.xml
+++ b/box-browse-sdk/src/main/res/layout/box_browsesdk_fragment_browse.xml
@@ -12,7 +12,9 @@
             android:id="@+id/box_browsesdk_items_recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/box_browsesdk_list_background"/>
+            android:background="@color/box_browsesdk_list_background"
+            android:clipToPadding="false"
+            />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <ImageView

--- a/box-browse-sdk/src/main/res/layout/fragment_box_filter_search_results.xml
+++ b/box-browse-sdk/src/main/res/layout/fragment_box_filter_search_results.xml
@@ -195,37 +195,36 @@
                 </LinearLayout>
             </LinearLayout>
         </ScrollView>
-        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        <LinearLayout
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentRight="true"
+            android:gravity="center_vertical|right"
             android:background="@android:color/white"
             android:id="@+id/clear_apply_bar"
-            android:layout_height="48dp">
+            >
+
             <Button
                 style="@style/BorderlessButton"
-                android:paddingLeft="24dp"
-                android:layout_toLeftOf="@+id/apply_button"
                 android:text="@string/clear_filters"
                 android:textColor="@color/filter_search_buttons"
                 android:id="@+id/clear_filters_button"
-                android:layout_centerVertical="true" />
+                />
             <Button
+                style="@style/BorderlessButton"
                 android:id="@+id/apply_button"
                 android:text="@string/apply"
-                android:paddingRight="24dp"
-                style="@style/BorderlessButton"
                 android:textColor="@color/filter_search_buttons"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true" />
-            <View
-                android:layout_width="match_parent"
-                android:background="?android:attr/listDivider"
-                android:layout_alignParentTop="true"
-                android:layout_height="1dp"/>
-        </RelativeLayout>
+                />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"
+            android:layout_above="@+id/clear_apply_bar"
+            />
+
     </RelativeLayout>
 
 </FrameLayout>

--- a/box-browse-sdk/src/main/res/values-ja/strings.xml
+++ b/box-browse-sdk/src/main/res/values-ja/strings.xml
@@ -22,6 +22,7 @@
 
     <string description="Default hint text for Search View" name="default_search_hint">検索</string>
     <string description="Label for button that launches screen to filter search results" name="filter_results_header">検索結果にフィルタを適用</string>
+    <string name="filter_search_results">検索結果をフィルタ</string>
     <string description="label for apply button in refine search results activity" name="apply">適用</string>
     <string description="label for clear filters button in refine search results activity" name="clear_filters">フィルタをクリア</string>
     <string description="Header for section that let you select file types to search for" name="file_type_label">ファイルの種類</string>

--- a/box-browse-sdk/src/main/res/values/colors.xml
+++ b/box-browse-sdk/src/main/res/values/colors.xml
@@ -7,7 +7,6 @@
     <color name="box_browsesdk_primary">#ffe0e0e0</color>
     <color name="box_browsesdk_primary_dark">#ff9e9e9e</color>
     <color name="box_browsesdk_divider">#14bdc3c7</color>
-    <color name="box_browsesdk_shadow">#88333333</color>
     <color name="box_browsesdk_list_background">#ffffff</color>
 
     <color name="box_browsesdk_media_list_background">@color/box_browsesdk_list_background</color>

--- a/box-browse-sdk/src/main/res/values/dimens.xml
+++ b/box-browse-sdk/src/main/res/values/dimens.xml
@@ -6,11 +6,9 @@
     <dimen name="box_browsesdk_list_item_height">72dp</dimen>
     <dimen name="box_browsesdk_media_list_item_height">120dp</dimen>
 
-    <dimen name="box_browsesdk_list_footer_padding">60dp</dimen>
     <dimen name="box_browsesdk_list_item_description_margin">72dp</dimen>
 
     <dimen name="box_browsesdk_secondary_action_width">56dp</dimen>
-    <dimen name="box_browsesdk_persistent_footer_height">48dp</dimen>
     <dimen name="box_browsesdk_thumb_width">40dp</dimen>
     <dimen name="box_browsesdk_thumb_padding">3dp</dimen>
     <dimen name="box_browsesdk_list_item_text_size">16sp</dimen>

--- a/box-browse-sdk/src/main/res/values/strings.xml
+++ b/box-browse-sdk/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
 
     <string name="default_search_hint" description="Default hint text for Search View">Search</string>
     <string name="filter_results_header" description="Label for button that launches screen to filter search results">Filter Results</string>
+    <string name="filter_search_results">Filter Search Results</string>
     <string name="apply" description="label for apply button in refine search results activity">Apply</string>
     <string name="clear_filters" description="label for clear filters button in refine search results activity">Clear Filters</string>
     <string name="file_type_label" description="Header for section that let you select file types to search for">File Type</string>

--- a/box-browse-sdk/src/main/res/values/styles.xml
+++ b/box-browse-sdk/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
-<resources xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<resources
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    >
     <style name="BrowseTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/box_browsesdk_primary</item>
         <item name="colorPrimaryDark">@color/box_browsesdk_primary_dark</item>
         <item name="colorAccent">@color/box_browsesdk_accent</item>
         <item name="searchViewStyle">@style/Widget.AppCompat.SearchView.ActionBar</item>
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 
     <style name="BoxDialogTitle" parent="@style/TextAppearance.AppCompat.Title">
@@ -74,6 +75,12 @@
         <item name="android:minHeight">40dp</item>
         <item name="android:orientation">horizontal</item>
         <item name="android:background">@drawable/button_settings_states2</item>
+    </style>
+
+    <style name="BoxToolbar">
+        <item name="android:background">?colorPrimary</item>
+        <item name="contentInsetStart">0dp</item>
+        <item name="contentInsetEnd">0dp</item>
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 ext {
     tools = [
             minSdk     : 28,
-            targetSdk  : 35,
-            compileSdk : 35,
+            targetSdk  : 36,
+            compileSdk : 36,
             versionCode: 2,
             versionName: '3.2.0-SNAPSHOT'
     ]


### PR DESCRIPTION
targetSdkを36に更新。
それに伴い以下の変更を実施した。
- [Activity#onBackPressedの呼び出しを移行](https://github.com/lisb/box-android-browse-sdk/commit/809cda48a841d3de32d05c6923d0eb2a9beaf014) 
- [edge-to-edge 対応](https://github.com/lisb/box-android-browse-sdk/commit/b7ea30064e1252c7231dd638f7b2764aef02e683)(ほとんどの変更はこちらによるもの)

以下の理由によりできるだけ変更が少なくてすむように対応した(見た目をおかしくしている影とかは流石に消した)。
- レイアウトXMLが色々とひどい
    - 色・サイズなどが直接指定されていることがよくある
    - RTL対応ほとんどされてない
    - View が無駄に入れ子になっていたりする
- View binding に未対応
- Kotlin へまだ移行していない